### PR TITLE
Fix some includes and warnings for Linux compilation

### DIFF
--- a/cmd.cpp
+++ b/cmd.cpp
@@ -1058,11 +1058,11 @@ CMD_PROC(takedata2)
 
 CMD_PROC(showclk)
 {
-	const int nSamples = 20;
+	const unsigned int nSamples = 20;
 	const int gain = 1;
 //	PAR_INT(gain,1,4);
 
-	int i, k;
+	unsigned int i, k;
 	uint32_t buffersize;
 	vector<uint16_t> data[20];
 
@@ -1116,11 +1116,11 @@ CMD_PROC(showclk)
 
 CMD_PROC(showctr)
 {
-	const int nSamples = 60;
+	const unsigned int nSamples = 60;
 	const int gain = 1;
 //	PAR_INT(gain,1,4);
 
-	int i, k;
+	unsigned int i, k;
 	uint32_t buffersize;
 	vector<uint16_t> data[20];
 
@@ -1188,8 +1188,8 @@ CMD_PROC(showctr)
 
 CMD_PROC(showsda)
 {
-	const int nSamples = 52;
-	int i, k;
+	const unsigned int nSamples = 52;
+	unsigned int i, k;
 	uint32_t buffersize;
 	vector<uint16_t> data[20];
 

--- a/psi46test.cpp
+++ b/psi46test.cpp
@@ -76,7 +76,13 @@ bool FindDTB()
 		
 		printf("Please choose device (0-%u): ", (nDev-1));
 		char choice[8];
-		fgets(choice, 8, stdin);
+
+		if(fgets(choice, 8, stdin) == NULL)
+		{
+		       printf("No DTB opened\n");
+		       return false;
+		}
+
 		sscanf (choice, "%d", &nr);
 		if (nr >= nDev)
 		{

--- a/rpcgen/cpp_scanner.cpp
+++ b/rpcgen/cpp_scanner.cpp
@@ -1,7 +1,7 @@
 // cpp_scanner.cpp
 
 #include "stdafx.h"
-
+#include <cstring>
 
 void CppScanner::SkipWhitespace()
 {


### PR DESCRIPTION
added include of cstring.h, changed var type for warnings (which default to errors with current compiler settings) concerning unsigned int / int comparison in cmd.cpp
