### PR TITLE
Remove back slash from script folder config. Linux stumbles here and sin...

### DIFF
--- a/psi46test.ini
+++ b/psi46test.ini
@@ -1,5 +1,5 @@
 DTBWMK8MY     // USB id for testboard
-script\       // command scripts
+script        // command scripts folder name
 -1            // (2) -1 = no prober
 0	      // 1 = sensor mounted
 40            // clock frequency in MHz (5, 10, 20, 40)


### PR DESCRIPTION
...ce we concatenate the "/" or "\" anyways it should just be the name.
